### PR TITLE
Update dependencies, Remove bs-webapi, Add some bindings

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -12,9 +12,6 @@
     "in-source": true
   },
   "suffix": ".bs.js",
-  "bs-dependencies": [
-    "bs-webapi"
-  ],
   "namespace": true,
   "refmt": 3
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,12 +34,6 @@
       "integrity": "sha512-bxeMwZPnJ90r48SavF60pkzGn7heaoHn7IF7fpPdh5L8WZfCzf76AikH2zWJii4QahUeInvRN1tNPWQt3ckKJQ==",
       "dev": true
     },
-    "bs-webapi": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/bs-webapi/-/bs-webapi-0.13.1.tgz",
-      "integrity": "sha512-JGngSUqyTrijGWURKbQYQE/3EDFcKszftQ0tqbaRBz6RvtIU+8Z+Lksc14aMdNpxuNiHWqhvoxbHnCvFdKLZHg==",
-      "dev": true
-    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,43 +1,43 @@
 {
   "name": "bs-pdfjs",
-  "version": "0.3.5",
+  "version": "0.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "ajv": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-      "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1",
-        "uri-js": "3.0.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-keywords": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
-      "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
     "big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
     "bs-platform": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-2.2.3.tgz",
-      "integrity": "sha1-2QWuEKXzYh5qc5BB36C1hIOiF08=",
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/bs-platform/-/bs-platform-4.0.14.tgz",
+      "integrity": "sha512-bxeMwZPnJ90r48SavF60pkzGn7heaoHn7IF7fpPdh5L8WZfCzf76AikH2zWJii4QahUeInvRN1tNPWQt3ckKJQ==",
       "dev": true
     },
     "bs-webapi": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/bs-webapi/-/bs-webapi-0.8.3.tgz",
-      "integrity": "sha1-sOMxFGq0Q5ZVD7pw/MsLvRFK+6A=",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/bs-webapi/-/bs-webapi-0.13.1.tgz",
+      "integrity": "sha512-JGngSUqyTrijGWURKbQYQE/3EDFcKszftQ0tqbaRBz6RvtIU+8Z+Lksc14aMdNpxuNiHWqhvoxbHnCvFdKLZHg==",
       "dev": true
     },
     "emojis-list": {
@@ -47,9 +47,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -59,27 +59,36 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
-    },
-    "loader-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "minimist": "^1.2.0"
       }
+    },
+    "loader-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "node-ensure": {
       "version": "0.0.0",
@@ -88,48 +97,48 @@
       "dev": true
     },
     "pdfjs-dist": {
-      "version": "2.0.466",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.466.tgz",
-      "integrity": "sha1-ybbEOMeeoV3z3wtPNH0Oz44KynQ=",
+      "version": "2.0.943",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz",
+      "integrity": "sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==",
       "dev": true,
       "requires": {
-        "node-ensure": "0.0.0",
-        "worker-loader": "1.1.1"
+        "node-ensure": "^0.0.0",
+        "worker-loader": "^2.0.0"
       }
     },
     "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "schema-utils": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+      "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
       "dev": true,
       "requires": {
-        "ajv": "6.4.0",
-        "ajv-keywords": "3.1.0"
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
       }
     },
     "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "^2.1.0"
       }
     },
     "worker-loader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-1.1.1.tgz",
-      "integrity": "sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.4.5"
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,9 @@
   "license": "MIT",
   "devDependencies": {
     "bs-platform": "^4.0.14",
-    "bs-webapi": "^0.13.1",
     "pdfjs-dist": "2.0.943"
   },
   "peerDependencies": {
-    "pdfjs-dist": "2.0.943",
-    "bs-webapi": "^0.13.0"
+    "pdfjs-dist": "2.0.943"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "bs-platform": "^2.1.0",
-    "bs-webapi": "^0.8.1",
-    "pdfjs-dist": "2.0.466"
+    "bs-platform": "^4.0.14",
+    "bs-webapi": "^0.13.1",
+    "pdfjs-dist": "2.0.943"
   },
   "peerDependencies": {
-    "pdfjs-dist": "2.0.466",
-    "bs-webapi": "^0.8.1"
+    "pdfjs-dist": "2.0.943",
+    "bs-webapi": "^0.13.0"
   }
 }

--- a/src/Document.re
+++ b/src/Document.re
@@ -54,15 +54,15 @@ module Source = {
     | TypedArray(_) => None;
 };
 
-[@bs.send.pipe: t] external getPage : int => Js.Promise.t(Page.t) = "";
+[@bs.send.pipe: t] external getPage: int => Js.Promise.t(Page.t) = "";
 
-[@bs.send] external getMetadata : t => Js.Promise.t(Metadata.t) = "";
+[@bs.send] external getMetadata: t => Js.Promise.t(Metadata.t) = "";
 
-[@bs.get] external getNumPages : t => int = "numPages";
+[@bs.get] external getNumPages: t => int = "numPages";
 
-[@bs.get] external fingerprint : t => string = "";
+[@bs.get] external fingerprint: t => string = "";
 
 [@bs.send]
-external getData : t => Js.Promise.t(Js.Typed_array.Int8Array.t) = "";
+external getData: t => Js.Promise.t(Js.Typed_array.Int8Array.t) = "";
 
-[@bs.send] external cleanup : t => unit = "";
+[@bs.send] external cleanup: t => unit = "";

--- a/src/Document.re
+++ b/src/Document.re
@@ -33,8 +33,8 @@ module Source = {
       Some(
         Url({
           "url": url,
-          "httpHeaders": Js.Nullable.from_opt(httpHeaders),
-          "withCredentials": Js.Nullable.from_opt(withCredentials),
+          "httpHeaders": Js.Nullable.fromOption(httpHeaders),
+          "withCredentials": Js.Nullable.fromOption(withCredentials),
         }),
       )
     | (None, Some(data), None, None) => Some(TypedArray({"data": data}))

--- a/src/Global.re
+++ b/src/Global.re
@@ -1,12 +1,12 @@
 type t;
 
-[@bs.module] external inst : t = "pdfjs-dist";
+[@bs.module] external inst: t = "pdfjs-dist";
 
 [@bs.set] [@bs.scope "GlobalWorkerOptions"]
-external setWorkerSrc : (t, string) => unit = "workerSrc";
+external setWorkerSrc: (t, string) => unit = "workerSrc";
 
-[@bs.send.pipe : t]
-external getDocument :
+[@bs.send.pipe: t]
+external getDocument:
   (
   [@bs.unwrap]
   [
@@ -18,14 +18,14 @@ external getDocument :
   "";
 
 let getDocument = (source, pdfjs) =>
-  switch source {
+  switch (source) {
   | Document.Source.Url(source) => getDocument(`UrlSource(source), pdfjs)
   | Document.Source.TypedArray(source) =>
     getDocument(`TypedArraySource(source), pdfjs)
   };
 
-[@bs.send.pipe : t]
-external renderTextLayer :
+[@bs.send.pipe: t]
+external renderTextLayer:
   {
     .
     "textContent": Js.Nullable.t(Page.TextContent.t),
@@ -33,7 +33,7 @@ external renderTextLayer :
     "viewport": Viewport.t,
     "container": Dom.element,
     "textDivs": Js.Array.t(Dom.element),
-    "enhanceTextSelection": Js.Nullable.t(bool)
+    "enhanceTextSelection": Js.Nullable.t(bool),
   } =>
   RenderTask.t(unit) =
   "";
@@ -46,7 +46,7 @@ let renderTextLayer =
       ~textContent=?,
       ~textContentStream=?,
       ~enhanceTextSelection=?,
-      inst
+      inst,
     ) =>
   renderTextLayer(
     {
@@ -55,20 +55,20 @@ let renderTextLayer =
       "textDivs": textDivs,
       "textContent": Js.Nullable.from_opt(textContent),
       "textContentStream": Js.Nullable.from_opt(textContentStream),
-      "enhanceTextSelection": Js.Nullable.from_opt(enhanceTextSelection)
+      "enhanceTextSelection": Js.Nullable.from_opt(enhanceTextSelection),
     },
-    inst
+    inst,
   );
 
-[@bs.scope "AnnotationLayer"] [@bs.send.pipe : t]
-external renderAnnotationLayer :
+[@bs.scope "AnnotationLayer"] [@bs.send.pipe: t]
+external renderAnnotationLayer:
   {
     .
     "annotations": array(Page.Annotation.t),
     "viewport": Viewport.t,
     "div": Dom.element,
     "page": Page.t,
-    "linkService": LinkService.t
+    "linkService": LinkService.t,
   } =>
   unit =
   "render";
@@ -81,7 +81,7 @@ let renderAnnotationLayer =
       "annotations": annotations,
       "div": div,
       "page": page,
-      "linkService": linkService
+      "linkService": linkService,
     },
-    inst
+    inst,
   );

--- a/src/Global.re
+++ b/src/Global.re
@@ -53,9 +53,9 @@ let renderTextLayer =
       "viewport": viewport,
       "container": container,
       "textDivs": textDivs,
-      "textContent": Js.Nullable.from_opt(textContent),
-      "textContentStream": Js.Nullable.from_opt(textContentStream),
-      "enhanceTextSelection": Js.Nullable.from_opt(enhanceTextSelection),
+      "textContent": Js.Nullable.fromOption(textContent),
+      "textContentStream": Js.Nullable.fromOption(textContentStream),
+      "enhanceTextSelection": Js.Nullable.fromOption(enhanceTextSelection),
     },
     inst,
   );

--- a/src/InternalUtils.re
+++ b/src/InternalUtils.re
@@ -3,4 +3,4 @@ let ( *> ) = (x, f) => {
   x;
 };
 
-let wrapBs = cb => [@bs] (a => cb(a));
+let wrapBs = cb => (. a) => cb(a);

--- a/src/LinkService.re
+++ b/src/LinkService.re
@@ -3,13 +3,13 @@ open InternalUtils;
 module Destination = {
   type t = (string, array(option(float)));
   /** Destination array is polymorphic, manually coorce to int */
-  external toNullableFloat : {.. "name": string} => Js.nullable(float) =
+  external toNullableFloat: {.. "name": string} => Js.nullable(float) =
     "%identity";
   /**
    * Parsing logic depends on viewer state e.g. height, scale, so we
    * convert into a reasonable state, but leave unparsed.
    **/
-  let decode = json : t => {
+  let decode = (json): t => {
     let name = json[1]##name;
     let values =
       json
@@ -30,9 +30,9 @@ module Viewer = {
       {
         .
         "pageNumber": int,
-        "destArray": {.}
+        "destArray": {.},
       } =>
-      unit
+      unit,
   };
   let make =
       (
@@ -41,10 +41,9 @@ module Viewer = {
         ~onSetRotation,
         ~onSetCurrentPageNumber,
         ~onScrollPageIntoView,
-        ()
+        (),
       ) => {
-    let _make:
-      (unit => int, int => Js.boolean, unit => int, int => Js.boolean, 'a) => t = [%raw
+    let _make: (unit => int, int => bool, unit => int, int => bool, 'a) => t = [%raw
       {|
       function (
         onGetCurrentPageNumber,
@@ -72,7 +71,7 @@ module Viewer = {
       onScrollPageIntoView(
         ~pageNumber=ev##pageNumber,
         ~destination=Destination.decode(ev##destArray),
-        ()
+        (),
       )
     );
   };
@@ -86,14 +85,14 @@ module Viewer = {
 module PdfLinkService = {
   type t;
   [@bs.new] [@bs.module "pdfjs-dist/lib/web/pdf_link_service"]
-  external make : unit => t = "PDFLinkService";
-  [@bs.send.pipe : t] external setDocument : (Document.t, string) => unit = "";
-  [@bs.send.pipe : t] external setViewer : Viewer.t => unit = "";
+  external make: unit => t = "PDFLinkService";
+  [@bs.send.pipe: t] external setDocument: (Document.t, string) => unit = "";
+  [@bs.send.pipe: t] external setViewer: Viewer.t => unit = "";
 };
 
 type t = PdfLinkService.t;
 
-let make = (~viewer, ~pdfDocument, ~baseUrl, ()) : t =>
+let make = (~viewer, ~pdfDocument, ~baseUrl, ()): t =>
   PdfLinkService.(
     make() *> setDocument(pdfDocument, baseUrl) *> setViewer(viewer)
   );

--- a/src/Page.re
+++ b/src/Page.re
@@ -4,12 +4,12 @@ type textContentStream;
 
 module TextItem = {
   type t;
-  [@bs.get] external str : t => string = "";
+  [@bs.get] external str: t => string = "";
 };
 
 module TextContent = {
   type t;
-  [@bs.get] external textItems : t => array(TextItem.t) = "items";
+  [@bs.get] external textItems: t => array(TextItem.t) = "items";
 };
 
 module Annotation = {
@@ -21,27 +21,26 @@ module Transform = {
   let make = (t1, t2, t3, t4, t5, t6) => [|t1, t2, t3, t4, t5, t6|];
 };
 
-[@bs.get] external pageNumber : t => int = "";
+[@bs.get] external pageNumber: t => int = "";
 
-[@bs.send]
-external getViewport : (t, float, float, Js.boolean) => Viewport.t = "";
+[@bs.send] external getViewport: (t, float, float, bool) => Viewport.t = "";
 
 let getViewport = (~scale, ~rotate, ~dontFlip=false, page) =>
-  getViewport(page, scale, rotate, Js.Boolean.to_js_boolean(dontFlip));
+  getViewport(page, scale, rotate, dontFlip);
 
 [@bs.send]
-external getAnnotations : t => Js.Promise.t(array(Annotation.t)) = "";
+external getAnnotations: t => Js.Promise.t(array(Annotation.t)) = "";
 
-[@bs.send] external streamTextContent : t => textContentStream = "";
+[@bs.send] external streamTextContent: t => textContentStream = "";
 
-[@bs.send] external getTextContent : t => Js.Promise.t(TextContent.t) = "";
+[@bs.send] external getTextContent: t => Js.Promise.t(TextContent.t) = "";
 
-[@bs.send.pipe : t]
-external getTextContentWithParams :
+[@bs.send.pipe: t]
+external getTextContentWithParams:
   {
     .
-    "normalizeWhitespace": Js.boolean,
-    "disableCombineTextItems": Js.boolean
+    "normalizeWhitespace": bool,
+    "disableCombineTextItems": bool,
   } =>
   Js.Promise.t(TextContent.t) =
   "getTextContent";
@@ -50,22 +49,21 @@ let getTextContentWithParams =
     (~normalizeWhitespace=false, ~disableCombineTextItems=false, pdfPage) =>
   getTextContentWithParams(
     {
-      "normalizeWhitespace": Js.Boolean.to_js_boolean(normalizeWhitespace),
-      "disableCombineTextItems":
-        Js.Boolean.to_js_boolean(disableCombineTextItems)
+      "normalizeWhitespace": normalizeWhitespace,
+      "disableCombineTextItems": disableCombineTextItems,
     },
-    pdfPage
+    pdfPage,
   );
 
 [@bs.send]
-external render :
+external render:
   (
     t,
     {
       .
       "canvasContext": Webapi.Canvas.Canvas2d.t,
       "viewport": Viewport.t,
-      "transform": Js.undefined(array(float))
+      "transform": Js.undefined(array(float)),
     }
   ) =>
   RenderTask.t(unit) =
@@ -77,6 +75,6 @@ let render = (~canvasContext, ~viewport, ~transform, page) =>
     {
       "viewport": viewport,
       "canvasContext": canvasContext,
-      "transform": Js.Undefined.from_opt(transform)
-    }
+      "transform": Js.Undefined.from_opt(transform),
+    },
   );

--- a/src/RenderTask.re
+++ b/src/RenderTask.re
@@ -1,9 +1,9 @@
 type t('a) = {
   .
   "promise": Js.Promise.t('a),
-  "cancel": unit => unit
+  "cancel": unit => unit,
 };
 
-[@bs.send] external cancel : t('a) => unit = "cancel";
+[@bs.send] external cancel: t('a) => unit = "cancel";
 
-[@bs.get] external promise : t('a) => Js.Promise.t('a) = "";
+[@bs.get] external promise: t('a) => Js.Promise.t('a) = "";

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -1,2 +1,10 @@
 [@bs.val] [@bs.module "pdfjs-dist/lib/web/ui_utils.js"]
 external getPDFFileNameFromURL: string => string = "";
+
+type util = {
+  .
+  [@bs.meth]
+  "transform": (Js.Array.t(float), Js.Array.t(float)) => Js.Array.t(float),
+};
+
+[@bs.module "pdfjs-dist"] external util: util = "Util";

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -1,2 +1,2 @@
 [@bs.val] [@bs.module "pdfjs-dist/lib/web/ui_utils.js"]
-external getPDFFileNameFromURL : string => string = "";
+external getPDFFileNameFromURL: string => string = "";

--- a/src/Viewport.re
+++ b/src/Viewport.re
@@ -9,19 +9,19 @@ type scale =
   | ScalePageFit
   | ScaleAuto;
 
-[@bs.get] external width : t => float = "";
+[@bs.get] external width: t => float = "";
 
-[@bs.get] external height : t => float = "";
+[@bs.get] external height: t => float = "";
 
-[@bs.get] external scale : t => float = "";
+[@bs.get] external scale: t => float = "";
 
-[@bs.send.pipe : t]
-external convertToPdfPoint : (float, float) => Js.Array.t(float) = "";
+[@bs.send.pipe: t]
+external convertToPdfPoint: (float, float) => Js.Array.t(float) = "";
 
-[@bs.send.pipe : t]
-external convertToViewportPoint : (float, float) => Js.Array.t(float) = "";
+[@bs.send.pipe: t]
+external convertToViewportPoint: (float, float) => Js.Array.t(float) = "";
 
-[@bs.send.pipe : t] external clone : {. "dontFlip": Js.boolean} => t = "";
+[@bs.send.pipe: t] external clone: {. "dontFlip": bool} => t = "";
 
 let clone = (~dontFlip=false, viewport) =>
-  clone({"dontFlip": Js.Boolean.to_js_boolean(dontFlip)}, viewport);
+  clone({"dontFlip": dontFlip}, viewport);

--- a/src/Viewport.re
+++ b/src/Viewport.re
@@ -15,6 +15,8 @@ type scale =
 
 [@bs.get] external scale: t => float = "";
 
+[@bs.get] external transform: t => Js.Array.t(float) = "";
+
 [@bs.send.pipe: t]
 external convertToPdfPoint: (float, float) => Js.Array.t(float) = "";
 

--- a/src/externals/Proxy.re
+++ b/src/externals/Proxy.re
@@ -3,14 +3,14 @@ type t;
 module Params = {
   type t;
   [@bs.obj]
-  external make :
+  external make:
     (
       ~get: (Js.t({..}), string) => 'a=?,
-      ~set: (Js.t({..}), string, 'a) => Js.boolean=?,
+      ~set: (Js.t({..}), string, 'a) => bool=?,
       unit
     ) =>
     t =
     "";
 };
 
-[@bs.new] external make : (Params.t, Js.t({..})) => Js.t({..}) = "Proxy";
+[@bs.new] external make: (Params.t, Js.t({..})) => Js.t({..}) = "Proxy";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,46 +2,47 @@
 # yarn lockfile v1
 
 
-ajv@^5.0.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
+ajv-keywords@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+  integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
+
+ajv@^6.1.0:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.2.tgz#caceccf474bf3fc3ce3b147443711a24063cc30d"
+  integrity sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==
   dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
+    fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-bs-platform@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.1.0.tgz#63560ff8f7142c9c0631559df1c35590b9f6d8b2"
-
-bs-webapi@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/bs-webapi/-/bs-webapi-0.8.1.tgz#8c14696dd5694ec8456111a6f1120c8d4c914cf4"
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+bs-platform@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-4.0.14.tgz#1d9e9622d59ebf4d39408d07b41997201c5f9750"
+  integrity sha512-bxeMwZPnJ90r48SavF60pkzGn7heaoHn7IF7fpPdh5L8WZfCzf76AikH2zWJii4QahUeInvRN1tNPWQt3ckKJQ==
 
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json5@^0.5.0:
   version "0.5.1"
@@ -59,22 +60,38 @@ node-ensure@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
 
-pdfjs-dist@^2.0.290:
-  version "2.0.290"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.290.tgz#96c5885635ae9bef2b51d5d7fb3283a5a069ca00"
+pdfjs-dist@2.0.943:
+  version "2.0.943"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz#32fb9a2d863df5a1d89521a0b3cd900c16e7edde"
+  integrity sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==
   dependencies:
     node-ensure "^0.0.0"
-    worker-loader "^1.1.0"
+    worker-loader "^2.0.0"
 
-schema-utils@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+schema-utils@^0.4.0:
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
+  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
   dependencies:
-    ajv "^5.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
 
-worker-loader@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-1.1.0.tgz#8cf21869a07add84d66f821d948d23c1eb98e809"
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
+worker-loader@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-2.0.0.tgz#45fda3ef76aca815771a89107399ee4119b430ac"
+  integrity sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==
   dependencies:
     loader-utils "^1.0.0"
-    schema-utils "^0.3.0"
+    schema-utils "^0.4.0"


### PR DESCRIPTION
I've done a couple of small things in this PR, please let me know your feedback as I'm rather new to Reason development.

I've updated the dependencies to newer versions and fixed a few deprecation warnings that were the result of those changes. There's quite some noise in the PR due to formatting, apparently the rules changed in refmt. I tried to keep those changes in a single commit to keep it readable.

I've removed the dependency on bs-webapi by using type arguments for everything related to the underlying canvas implementation. The reason for this is that I'm using nodejs with corresponding bindings, so the bs-webapi ones don't work as I don't have a DOM. This allows people to supply their own canvas bindings.

I've added a few more pdfjs bindings that were missing. Most notable is the CanvasFactory stuff that I added. This is necessary to use pdfjs with node, see here for an example of how this is used in vanilla Javascript: https://github.com/mozilla/pdf.js/blob/master/examples/node/pdf2png/pdf2png.js

Again, please let me know your feedback.